### PR TITLE
Fix: Boolean variable conversion fails with recycled string values

### DIFF
--- a/wf_common.py
+++ b/wf_common.py
@@ -10,11 +10,24 @@ def envvar(v: str, dv: str) -> str:
 
 #for checkboxes - unchecked aka `0` returns `false`
 def envvar_to_bool(v: str) -> str:
-  try:
-    b = int(os.getenv(v))
-  except:
+  raw_val = os.getenv(v)
+  
+  # Handle both '1'/'0' and 'true'/'false' strings
+  if raw_val is None:
     b = 0
-  return str(bool(b)).lower()
+  elif raw_val.lower() in ('true', '1', 'yes'):
+    b = 1
+  elif raw_val.lower() in ('false', '0', 'no', ''):
+    b = 0
+  else:
+    # Try to parse as integer
+    try:
+      b = int(raw_val)
+    except:
+      b = 0
+  
+  result = str(bool(b)).lower()
+  return result
 
 def envvar_to_int(v: str, dv: int=0) -> int:
   try:


### PR DESCRIPTION
## Why Change

The save_to_current checkbox variable was always reverting to 'false' after 
the first workflow run, breaking the "Save images to current Finder window" 
feature. The envvar_to_bool() function only handled numeric strings ('0', '1') 
from checkbox inputs but failed when Alfred recycled the string boolean values 
('true', 'false') that the workflow itself output. The conversion int('true') 
raised a ValueError, caught by the exception handler, and defaulted to 0.

## How Change

Enhanced envvar_to_bool() to explicitly handle both numeric strings ('0', '1') 
AND string boolean values ('true', 'false', 'yes', 'no') before attempting 
integer conversion. Added proper None and empty string handling with graceful 
fallback for unexpected values.

## What Changed
- wf_common.py: Rewrote envvar_to_bool() with explicit string matching

## Testing

Tested on macOS 15.0+ with Alfred 5.x. Verified correct behavior with:
- Checkbox inputs ('0', '1')
- Recycled variables ('true', 'false')
- Edge cases (None, empty string, 'yes', 'no')

Fixes save_to_current checkbox persistence across workflow executions.
